### PR TITLE
Revamp temporary festival website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,110 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <meta charset="UTF-8">
-  <title>第77回岐阜大学祭 仮設ページに転送中...</title>
-  <meta http-equiv="refresh" content="5; url=https://sites.google.com/view/77gidaisai-temporary/" />
-  <script>
-    window.location.replace("https://sites.google.com/view/77gidaisai-temporary/");
-  </script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>第77回岐阜大学祭 | トップ</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <p>仮設ページに移動しています。自動で移動しない場合は、<a href="https://sites.google.com/view/77gidaisai-temporary/">こちらをクリック</a>してください。</p>
+  <header>
+    <div class="header-inner">
+      <h1 class="site-title">第77回 岐阜大学祭</h1>
+      <nav aria-label="サイト内ナビゲーション">
+        <ul>
+          <li><a href="index.html">トップ</a></li>
+          <li><a href="sponsors.html">ご協賛</a></li>
+          <li><a href="programs.html">企画一覧</a></li>
+          <li><a href="news.html">お知らせ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero">
+      <span class="badge">Blooming ― さらなる挑戦と成長の3日間</span>
+      <h1>岐大祭とは？</h1>
+      <p>
+        第77回岐阜大学祭は、岐阜大学で3日間にわたり開催される地域最大級の学園祭です。
+        学生による多彩な企画や模擬店がキャンパスを彩り、地域のみなさまと一緒に作り上げる特別な時間が広がります。
+      </p>
+      <p class="tagline">テーマ「Blooming」に込めた想いとともに、岐阜大学生の新たな挑戦をぜひご体感ください。</p>
+    </section>
+
+    <section class="section" aria-labelledby="mascot-heading">
+      <h2 id="mascot-heading">岐大祭マスコットキャラクター</h2>
+      <div class="grid-2">
+        <div>
+          <h3>ぎだにゃん</h3>
+          <p>
+            岐大祭を盛り上げる公式マスコット「ぎだにゃん」が今年も登場します。会場内の撮影スポットや、
+            さまざまな企画で皆さんをお迎えします。見かけたら、ぜひ声をかけてください！
+          </p>
+        </div>
+        <div>
+          <h3>このホームページについて</h3>
+          <p>
+            現在、不具合により以前のホームページが閲覧できない状況となっております。ご心配・ご迷惑をおかけし申し訳ございません。
+            当面はこちらの臨時ホームページにて情報発信および統一募集を行います。
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="venue-heading">
+      <h2 id="venue-heading">会場・アクセス</h2>
+      <div class="grid-2">
+        <div>
+          <dl>
+            <dt>会場</dt>
+            <dd>岐阜大学</dd>
+            <dt>住所</dt>
+            <dd>〒501-1193 岐阜県岐阜市柳戸1-1</dd>
+          </dl>
+        </div>
+        <div>
+          <dl>
+            <dt>JR岐阜駅から</dt>
+            <dd>9番乗り場からバスで約30分</dd>
+            <dt>名鉄岐阜駅から</dt>
+            <dd>5番乗り場からバスで約30分</dd>
+          </dl>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="contact-heading">
+      <h2 id="contact-heading">お問い合わせ先</h2>
+      <p>ご不明点がございましたら、各担当までお気軽にお問い合わせください。（★ を <span aria-label="アットマーク gmail ドットコム">@gmail.com</span> に置き換えてください）</p>
+      <div class="contact-grid">
+        <div class="contact-card">
+          <h3>模擬店企画</h3>
+          <p>有志局 模擬店部<br />77gidaisai+mogiten★</p>
+        </div>
+        <div class="contact-card">
+          <h3>有志ステージ企画</h3>
+          <p>有志局 有志ステージ部<br />77gidaisai+stage★</p>
+        </div>
+        <div class="contact-card">
+          <h3>屋内企画</h3>
+          <p>有志局 屋内部<br />77gidaisai+okunai★</p>
+        </div>
+        <div class="contact-card">
+          <h3>その他・渉外</h3>
+          <p>渉外局<br />77gidaisai+ext★</p>
+        </div>
+      </div>
+      <dl>
+        <dt>主催</dt>
+        <dd>全学行事団体 岐阜大学祭実行委員会</dd>
+        <dt>所在地</dt>
+        <dd>〒501-1193 岐阜県岐阜市柳戸1-1 岐阜大学 大学会館内</dd>
+      </dl>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 岐阜大学祭実行委員会</p>
+    <p>岐阜大学 〒501-1193 岐阜県岐阜市柳戸1-1</p>
+  </footer>
 </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>第77回岐阜大学祭 | お知らせ</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <h1 class="site-title">第77回 岐阜大学祭</h1>
+      <nav aria-label="サイト内ナビゲーション">
+        <ul>
+          <li><a href="index.html">トップ</a></li>
+          <li><a href="sponsors.html">ご協賛</a></li>
+          <li><a href="programs.html">企画一覧</a></li>
+          <li><a href="news.html" aria-current="page">お知らせ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero">
+      <span class="badge">岐大祭からのお知らせ</span>
+      <h1>最新情報</h1>
+      <p>岐阜大学祭実行委員会からのお知らせを掲載しています。最新の情報をご確認ください。</p>
+    </section>
+
+    <section class="section" aria-labelledby="news-heading">
+      <h2 id="news-heading">お知らせ一覧</h2>
+      <div class="notice-list">
+        <article class="notice-item">
+          <h3>R7/8/5 出展者募集要項の一部を改正します</h3>
+          <p>お問い合わせ内容を踏まえ、出展者募集要項の一部を改正いたします。詳細は準備が整い次第ご案内いたします。</p>
+        </article>
+        <article class="notice-item">
+          <h3>R7/07/10 臨時ホームページを開設いたしました</h3>
+          <p>不具合により従来のホームページが閲覧できなくなったため、臨時ホームページを開設しました。ご不便をおかけしますが、こちらをご利用ください。</p>
+        </article>
+        <article class="notice-item">
+          <h3>R7/07/10 統一募集についてのお知らせ</h3>
+          <p>統一募集は引き続き本ホームページで受け付けております。皆様のご応募をお待ちしております。</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="contact-heading">
+      <h2 id="contact-heading">お問い合わせ先</h2>
+      <p>★ を <span aria-label="アットマーク gmail ドットコム">@gmail.com</span> に置き換えてご連絡ください。</p>
+      <div class="contact-grid">
+        <div class="contact-card">
+          <h3>模擬店企画</h3>
+          <p>有志局 模擬店部<br />77gidaisai+mogiten★</p>
+        </div>
+        <div class="contact-card">
+          <h3>有志ステージ企画</h3>
+          <p>有志局 有志ステージ部<br />77gidaisai+stage★</p>
+        </div>
+        <div class="contact-card">
+          <h3>屋内企画</h3>
+          <p>有志局 屋内部<br />77gidaisai+okunai★</p>
+        </div>
+        <div class="contact-card">
+          <h3>その他・渉外</h3>
+          <p>渉外局<br />77gidaisai+ext★</p>
+        </div>
+      </div>
+      <dl>
+        <dt>主催</dt>
+        <dd>全学行事団体 岐阜大学祭実行委員会</dd>
+        <dt>所在地</dt>
+        <dd>〒501-1193 岐阜県岐阜市柳戸1-1 岐阜大学 大学会館内</dd>
+      </dl>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 岐阜大学祭実行委員会</p>
+    <p>岐阜大学 〒501-1193 岐阜県岐阜市柳戸1-1</p>
+  </footer>
+</body>
+</html>

--- a/programs.html
+++ b/programs.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>第77回岐阜大学祭 | 企画一覧</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <h1 class="site-title">第77回 岐阜大学祭</h1>
+      <nav aria-label="サイト内ナビゲーション">
+        <ul>
+          <li><a href="index.html">トップ</a></li>
+          <li><a href="sponsors.html">ご協賛</a></li>
+          <li><a href="programs.html" aria-current="page">企画一覧</a></li>
+          <li><a href="news.html">お知らせ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero">
+      <span class="badge">岐大祭を彩るラインアップ</span>
+      <h1>企画一覧</h1>
+      <p>多彩な企画が岐阜大学キャンパスに勢揃いします。気になる企画をチェックして、当日の楽しみを広げてください。</p>
+    </section>
+
+    <section class="section" aria-labelledby="program-list-heading">
+      <h2 id="program-list-heading">主な企画</h2>
+      <div class="notice-list">
+        <article class="notice-item">
+          <h3>屋内（展示）企画</h3>
+          <p>研究発表やアート展示など、学生の個性と情熱が詰まった作品と出会えるスペースです。</p>
+        </article>
+        <article class="notice-item">
+          <h3>有志ステージ企画</h3>
+          <p>音楽・ダンス・パフォーマンスなど、学生有志による熱いステージが目白押しです。</p>
+        </article>
+        <article class="notice-item">
+          <h3>模擬店企画</h3>
+          <p>バラエティ豊かなグルメや体験ブースが並びます。岐大生のアイデアが光る模擬店をお楽しみください。</p>
+        </article>
+        <article class="notice-item">
+          <h3>お笑いライブ企画</h3>
+          <p>笑いに包まれるスペシャルプログラム。詳細は決まり次第、随時お知らせします。</p>
+        </article>
+        <article class="notice-item">
+          <h3>ビンゴ企画</h3>
+          <p>豪華景品が当たるチャンス！小さなお子様から大人まで、みんなで盛り上がれる人気企画です。</p>
+        </article>
+        <article class="notice-item">
+          <h3>フリーマーケット企画</h3>
+          <p>掘り出し物が見つかるフリマ。学生と地域の方々が交流できるアットホームな空間です。</p>
+        </article>
+        <article class="notice-item">
+          <h3>ぎだにゃん企画</h3>
+          <p>岐大祭マスコット「ぎだにゃん」と一緒に楽しめるイベントやフォトスポットをご用意しています。</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="contact-heading">
+      <h2 id="contact-heading">お問い合わせ先</h2>
+      <p>各企画に関するお問い合わせは、担当部署までお願いします。（★ を <span aria-label="アットマーク gmail ドットコム">@gmail.com</span> に置き換えてください）</p>
+      <div class="contact-grid">
+        <div class="contact-card">
+          <h3>模擬店企画</h3>
+          <p>有志局 模擬店部<br />77gidaisai+mogiten★</p>
+        </div>
+        <div class="contact-card">
+          <h3>有志ステージ企画</h3>
+          <p>有志局 有志ステージ部<br />77gidaisai+stage★</p>
+        </div>
+        <div class="contact-card">
+          <h3>屋内企画</h3>
+          <p>有志局 屋内部<br />77gidaisai+okunai★</p>
+        </div>
+        <div class="contact-card">
+          <h3>その他・渉外</h3>
+          <p>渉外局<br />77gidaisai+ext★</p>
+        </div>
+      </div>
+      <dl>
+        <dt>主催</dt>
+        <dd>全学行事団体 岐阜大学祭実行委員会</dd>
+        <dt>所在地</dt>
+        <dd>〒501-1193 岐阜県岐阜市柳戸1-1 岐阜大学 大学会館内</dd>
+      </dl>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 岐阜大学祭実行委員会</p>
+    <p>岐阜大学 〒501-1193 岐阜県岐阜市柳戸1-1</p>
+  </footer>
+</body>
+</html>

--- a/sponsors.html
+++ b/sponsors.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>第77回岐阜大学祭 | ご協賛のお願い</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <h1 class="site-title">第77回 岐阜大学祭</h1>
+      <nav aria-label="サイト内ナビゲーション">
+        <ul>
+          <li><a href="index.html">トップ</a></li>
+          <li><a href="sponsors.html" aria-current="page">ご協賛</a></li>
+          <li><a href="programs.html">企画一覧</a></li>
+          <li><a href="news.html">お知らせ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero">
+      <span class="badge">ご支援を通じて、未来を咲かせる</span>
+      <h1>ご協賛のお願い</h1>
+      <p>
+        岐阜大学祭実行委員会は、2025年11月に「第77回岐阜大学祭」を開催いたします。テーマは「Blooming」。
+        出展者・運営者として挑戦する岐阜大学生が、さらなる成長と発展を遂げるきっかけとなる学園祭を目指しています。
+        企業・団体の皆様からの温かいご支援を賜りたく、心よりお願い申し上げます。
+      </p>
+    </section>
+
+    <section class="section" aria-labelledby="materials-heading">
+      <h2 id="materials-heading">ご検討資料・申込書</h2>
+      <p>以下の資料を別ページでご確認いただけます。ぜひ趣旨をご理解いただき、ご協力を賜りますようお願い申し上げます。</p>
+      <div class="external-links">
+        <a href="https://drive.google.com/file/d/1mI3ZsnLot40y395RTdwthegMG1idrmjk/view?usp=sharing" target="_blank" rel="noopener">ご検討資料 (PDF)</a>
+        <a href="https://drive.google.com/file/d/1bZCL1MGURaUkDgif8C0wk4kCEj_J1bjz/view" target="_blank" rel="noopener">協賛申込書 (PDF)</a>
+        <a href="https://docs.google.com/document/d/1pFKQlchJ-rlO6rT-uQYFFhpPVG04dZEX/view" target="_blank" rel="noopener">協賛申込書 (Word)</a>
+      </div>
+      <p>ご検討資料をご確認のうえ、お問い合わせをお待ちしております。メールを受領してから3活動日（平日）以内に返信いたします。</p>
+    </section>
+
+    <section class="section" aria-labelledby="contact-heading">
+      <h2 id="contact-heading">お問い合わせ先</h2>
+      <p>★ を <span aria-label="アットマーク gmail ドットコム">@gmail.com</span> に置き換えてご連絡ください。</p>
+      <div class="contact-grid">
+        <div class="contact-card">
+          <h3>模擬店企画</h3>
+          <p>有志局 模擬店部<br />77gidaisai+mogiten★</p>
+        </div>
+        <div class="contact-card">
+          <h3>有志ステージ企画</h3>
+          <p>有志局 有志ステージ部<br />77gidaisai+stage★</p>
+        </div>
+        <div class="contact-card">
+          <h3>屋内企画</h3>
+          <p>有志局 屋内部<br />77gidaisai+okunai★</p>
+        </div>
+        <div class="contact-card">
+          <h3>その他・渉外</h3>
+          <p>渉外局<br />77gidaisai+ext★</p>
+        </div>
+      </div>
+      <dl>
+        <dt>主催</dt>
+        <dd>全学行事団体 岐阜大学祭実行委員会</dd>
+        <dt>所在地</dt>
+        <dd>〒501-1193 岐阜県岐阜市柳戸1-1 岐阜大学 大学会館内</dd>
+      </dl>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 岐阜大学祭実行委員会</p>
+    <p>岐阜大学 〒501-1193 岐阜県岐阜市柳戸1-1</p>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,262 @@
+:root {
+  --primary: #0f4c81;
+  --secondary: #f6b042;
+  --light: #fdfdfd;
+  --text: #333;
+  --muted: #6b7280;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+  color: var(--text);
+  background: #f4f6fb;
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+header {
+  background: var(--primary);
+  color: white;
+  padding: 1.5rem 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.site-title {
+  margin: 0;
+  font-size: 1.75rem;
+  letter-spacing: 0.04em;
+}
+
+nav ul {
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-weight: 600;
+}
+
+nav a {
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  transition: background 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.hero {
+  background: linear-gradient(135deg, #fff 0%, #f0f7ff 100%);
+  border-radius: 1.25rem;
+  padding: 2.5rem;
+  box-shadow: 0 20px 40px rgba(15, 76, 129, 0.1);
+  margin-bottom: 2.5rem;
+}
+
+.hero h1 {
+  margin-top: 0;
+  font-size: 2.2rem;
+  color: var(--primary);
+}
+
+.hero p {
+  font-size: 1.1rem;
+  line-height: 1.8;
+}
+
+.section {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.75rem;
+  box-shadow: 0 12px 24px rgba(15, 76, 129, 0.08);
+  margin-bottom: 2rem;
+}
+
+.section h2 {
+  margin-top: 0;
+  border-left: 0.35rem solid var(--secondary);
+  padding-left: 0.75rem;
+  font-size: 1.6rem;
+}
+
+.grid-2 {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #fff3d7;
+  color: #7a4d00;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.contact-card {
+  background: #f9fafc;
+  border: 1px solid #e0e7ff;
+  border-radius: 0.85rem;
+  padding: 1rem;
+  box-shadow: 0 8px 16px rgba(15, 76, 129, 0.04);
+}
+
+.contact-card h3 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+dl {
+  margin: 0;
+}
+
+dl + dl {
+  margin-top: 1.25rem;
+}
+
+dt {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+dd {
+  margin: 0.25rem 0 0.75rem 0;
+}
+
+footer {
+  background: #0b3054;
+  color: white;
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+footer p {
+  margin: 0.25rem 0;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--primary);
+  color: white;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 18px rgba(15, 76, 129, 0.2);
+  text-decoration: none;
+}
+
+.notice-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.notice-item {
+  background: #f9fafc;
+  border-left: 0.4rem solid var(--primary);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 10px 20px rgba(15, 76, 129, 0.06);
+}
+
+.notice-item h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.notice-item p {
+  margin: 0.5rem 0 0;
+  line-height: 1.7;
+}
+
+.external-links {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.external-links a {
+  display: block;
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #dbeafe;
+  background: #f1f7ff;
+  font-weight: 600;
+  transition: transform 0.2s ease;
+}
+
+.external-links a:hover {
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.tagline {
+  margin: 1rem 0 0;
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  nav ul {
+    flex-wrap: wrap;
+  }
+
+  .hero {
+    padding: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the redirect placeholder with a full landing page for the 77th Gifu University Festival
- add dedicated pages for sponsorship information, program lineup, and news updates
- introduce a shared stylesheet for cohesive visual design across all pages

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68dca8aae744832cbeab858fd9409ea3